### PR TITLE
Make config file a dotfile to make BitBar ignore it

### DIFF
--- a/bx_in_th.15s.rb
+++ b/bx_in_th.15s.rb
@@ -9,6 +9,10 @@ PAIRINGS = JSON.parse('{"1":{"pairing_id":1,"primary_currency":"THB","secondary_
 DEFAULT_PAIRING_ID = 26 # THB-OMG
 
 def run
+  # TODO: Remove this line
+  # More info: https://github.com/narze/bitbar-bx/pull/1
+  rename_old_settings_file
+
   settings = load_settings
   pairing_id = settings['pairing_id'] || DEFAULT_PAIRING_ID
 
@@ -85,6 +89,20 @@ def load_settings
   else
     {}
   end
+end
+
+# TODO: Remove this method
+# More info: https://github.com/narze/bitbar-bx/pull/1
+def rename_old_settings_file
+  if File.exist? old_settings_file
+    File.rename(old_settings_file, settings_file)
+  end
+end
+
+# TODO: Remove this method
+# More info: https://github.com/narze/bitbar-bx/pull/1
+def old_settings_file
+  File.join(File.dirname(__FILE__), "bx_in_th.conf")
 end
 
 def settings_file

--- a/bx_in_th.15s.rb
+++ b/bx_in_th.15s.rb
@@ -88,7 +88,7 @@ def load_settings
 end
 
 def settings_file
-  File.join(File.dirname(__FILE__), "bx_in_th.conf")
+  File.join(File.dirname(__FILE__), ".bx_in_th.conf")
 end
 
 begin


### PR DESCRIPTION
There's a yellow icon appear as the screenshot below.
<img width="256" alt="screen shot 2017-09-06 at 6 07 20 pm" src="https://user-images.githubusercontent.com/7040242/30109092-35f981f8-932f-11e7-95ff-f53c20222795.png">
It happens because BitBar is trying to run `bx_in_th.conf` as a plugin, which it'll fail.
This can be fixed by adding `.` to the start of the file so that BitBar won't run it.
 ([ref](https://github.com/matryer/bitbar/issues/189#issuecomment-173868587))

The problem will still occur since `bx_in_th.conf` has been created. We can make this plugin delete the file if it exists (but it'll be confusing later on why that code was there). Or, we can write an instruction to fix this bug in README. I'm not sure how should we handle this.