### PR TITLE
Fix invisible "Go to bx.in.th" menu in black menu bar

### DIFF
--- a/bx_in_th.15s.rb
+++ b/bx_in_th.15s.rb
@@ -62,7 +62,7 @@ def output(d)
     "Total : #{asks['total']} orders",
     "---",
     "Change pairing | bash='#{__FILE__}' param1=set_pairing terminal=false",
-    "Go to bx.in.th | href=https://bx.in.th color=black",
+    "Go to bx.in.th | href=https://bx.in.th",
   ]
 
   [


### PR DESCRIPTION
To fix #2.

Hardcoding it to be black cause that menu text to be the same color as the background in dark menu bar, making it invisible.

Simply fix it by removing `color=black` in `"Go to bx.in.th | href=https://bx.in.th color=black",`. It'll be black by default anyway since it's clickable.